### PR TITLE
Fix open() call with O_CREAT flag (mode parameter must be provided)

### DIFF
--- a/dbgen/bm_utils.c
+++ b/dbgen/bm_utils.c
@@ -339,7 +339,7 @@ FILE *tbl_open(int tbl, char *mode) {
   }
 
   if (S_ISFIFO(fstats.st_mode)) {
-    retcode = open(fullpath, ((*mode == 'r') ? O_RDONLY : O_WRONLY) | O_CREAT);
+    retcode = open(fullpath, ((*mode == 'r') ? O_RDONLY : O_WRONLY) | O_CREAT, 0644);
     f = fdopen(retcode, mode);
   } else {
 


### PR DESCRIPTION
When built on Ubuntu 21.04, the `dbgen` crashes complaining that `open()` is called with `O_CREAT` flag, but the mode parameter is not provided, which is in line with the `open()` documentation:
```
The mode argument must be supplied if O_CREAT or O_TMPFILE is specified in flags; if it is not supplied, some arbitrary bytes from the stack will be applied as the file mode.
```
The PR adds the required mode parameter in line with the similar calls below. After this change `dbgen` runs successfully on my system.